### PR TITLE
Fix lint warnings.

### DIFF
--- a/crates/graphql/src/schema.rs
+++ b/crates/graphql/src/schema.rs
@@ -84,7 +84,7 @@ impl Creator {
                      trait_type, value, ..
                  }| {
                     *groups
-                        .entry(trait_type.unwrap().to_lowercase().clone())
+                        .entry(trait_type.unwrap().to_lowercase())
                         .or_insert_with(HashMap::new)
                         .entry(value)
                         .or_insert(0) += 1;

--- a/crates/indexer/src/accountsdb/client.rs
+++ b/crates/indexer/src/accountsdb/client.rs
@@ -27,7 +27,7 @@ struct HttpProducers {
 impl std::panic::UnwindSafe for HttpProducers {}
 impl std::panic::RefUnwindSafe for HttpProducers {}
 
-// RpcClient and Diesel don't implement Debug for some reason
+// RpcClient doesn't implement Debug for some reason
 #[allow(missing_debug_implementations)]
 /// Wrapper for handling networking logic
 pub struct Client {

--- a/crates/indexer/src/db.rs
+++ b/crates/indexer/src/db.rs
@@ -1,3 +1,5 @@
+//! Support module for running Diesel operations in an async context.
+
 use std::fmt;
 
 use indexer_core::{db, db::PooledConnection};

--- a/crates/indexer/src/http/client.rs
+++ b/crates/indexer/src/http/client.rs
@@ -9,6 +9,7 @@ use crate::{db::Pool, prelude::*};
 #[derive(Debug, Clone, Copy)]
 pub struct ArTxid(pub [u8; 32]);
 
+/// Wrapper for handling networking logic
 #[derive(Debug)]
 pub struct Client {
     db: Pool,
@@ -34,6 +35,7 @@ impl Client {
     }
 
     /// Get a reference to the database
+    #[must_use]
     pub fn db(&self) -> &Pool {
         &self.db
     }


### PR DESCRIPTION
Buried in here is logic for (finally) actually calling the account handler for AuctionCache.