### PR TITLE
remove breaking toLowerCase on trait_type

### DIFF
--- a/crates/graphql/src/schema.rs
+++ b/crates/graphql/src/schema.rs
@@ -85,7 +85,7 @@ impl Creator {
                      trait_type, value, ..
                  }| {
                     *groups
-                        .entry(trait_type.unwrap().to_lowercase())
+                        .entry(trait_type.unwrap().into())
                         .or_insert_with(HashMap::new)
                         .entry(value)
                         .or_insert(0) += 1;


### PR DESCRIPTION
Hopefully there wasn't a reason behind this. It breaks most filter sets. 

If we did have a reason for this, one route might be to add a to_lowercase to all incoming filters. We'd have to change the query and utilize a LOWER. Both could work. Not sure which is better at the moment. Let's talk.