### PR TITLE
returning assets url in graphql. Moving AssetIdentifier logic to indexer-core

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 ARWEAVE_URL=https://arweave.net/
 IPFS_CDN=https://ipfs.cache.holaplex.com/
 ARWEAVE_CDN=https://arweave.net/
+ASSETS_CDN=https://assets.holaplex.com/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "constant_time_eq",
- "digest 0.10.1",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1330,11 +1330,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -1573,13 +1574,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
- "generic-array",
  "subtle",
 ]
 
@@ -2744,7 +2744,9 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "base64 0.13.0",
  "chrono",
+ "cid",
  "clap 3.0.7",
  "dashmap",
  "diesel",
@@ -2756,6 +2758,7 @@ dependencies = [
  "rand 0.8.4",
  "serde_json",
  "solana-sdk",
+ "url",
  "uuid",
 ]
 
@@ -2766,6 +2769,7 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "async-trait",
+ "base64 0.13.0",
  "dataloader",
  "juniper",
  "metaplex-indexer-core",
@@ -4025,7 +4029,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.1",
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,3 +37,7 @@ diesel_full_text_search = { version = "1.0.1", git = "https://github.com/diesel-
 # Solana
 solana-sdk = "1.8.3"
 
+# Asset id
+base64 = "0.13.0"
+cid = "0.8.3"
+url = "2.2.2"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -39,5 +39,5 @@ solana-sdk = "1.8.3"
 
 # Asset id
 base64 = "0.13.0"
-cid = "0.8.3"
+cid = "0.7.0"
 url = "2.2.2"

--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -1,5 +1,4 @@
-//! AssetIdentifier utils - Parse and capture tx and cid
-use base64::display::Base64Display;
+//! ``AssetIdentifier`` utils - Parse and capture tx and cid
 use cid::Cid;
 use url::Url;
 /// An Arweave transaction ID
@@ -61,19 +60,9 @@ impl AssetIdentifier {
             Err(()) => (),
         }
     }
-    /// Extract cid from asset
-    pub fn get_cid_with_svc(&self) -> String {
-        if self.arweave.is_some() {
-            format!(
-                "arweave/{}",
-                Base64Display::with_config(&self.arweave.unwrap().0, base64::URL_SAFE_NO_PAD)
-                    .to_string()
-            )
-        } else {
-            format!("ipfs/{}", self.ipfs.unwrap().to_string())
-        }
-    }
+
     /// parse cid from url
+    #[must_use]
     pub fn new(url: &Url) -> Self {
         let mut ipfs = Ok(None);
         let mut arweave = Ok(None);

--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -1,0 +1,96 @@
+//! AssetIdentifier utils - Parse and capture tx and cid
+use base64::display::Base64Display;
+use cid::Cid;
+use url::Url;
+/// An Arweave transaction ID
+#[derive(Debug, Clone, Copy)]
+pub struct ArTxid(pub [u8; 32]);
+
+/// Struct to hold tx ids
+#[derive(Debug, Clone, Copy)]
+pub struct AssetIdentifier {
+    /// ipfs cid
+    pub ipfs: Option<Cid>,
+    /// Arweave tx id
+    pub arweave: Option<ArTxid>,
+}
+
+impl AssetIdentifier {
+    fn visit_url(url: &Url, mut f: impl FnMut(&str)) {
+        Some(url.scheme())
+            .into_iter()
+            .chain(url.domain().into_iter().flat_map(|s| s.split('.')))
+            .chain(Some(url.username()))
+            .chain(url.password())
+            .chain(Some(url.path()))
+            .chain(url.path_segments().into_iter().flatten())
+            .chain(url.query())
+            .chain(url.fragment().into_iter().flat_map(|s| s.split('/')))
+            .for_each(&mut f);
+
+        url.query_pairs().for_each(|(k, v)| {
+            f(k.as_ref());
+            f(v.as_ref());
+        });
+    }
+
+    fn try_ipfs(s: &str) -> Option<Cid> {
+        s.try_into().ok()
+    }
+
+    fn try_arweave(s: &str) -> Option<ArTxid> {
+        [
+            base64::URL_SAFE,
+            base64::URL_SAFE_NO_PAD,
+            base64::STANDARD,
+            base64::STANDARD_NO_PAD,
+        ]
+        .into_iter()
+        .find_map(|c| {
+            base64::decode_config(s.as_bytes(), c)
+                .ok()
+                .and_then(|v| v.try_into().ok())
+                .map(ArTxid)
+        })
+    }
+
+    fn advance_heuristic<T>(state: &mut Result<Option<T>, ()>, value: T) {
+        match state {
+            Ok(None) => *state = Ok(Some(value)),
+            Ok(Some(_)) => *state = Err(()),
+            Err(()) => (),
+        }
+    }
+    /// Extract cid from asset
+    pub fn get_cid_with_svc(&self) -> String {
+        if self.arweave.is_some() {
+            format!(
+                "arweave/{}",
+                Base64Display::with_config(&self.arweave.unwrap().0, base64::URL_SAFE_NO_PAD)
+                    .to_string()
+            )
+        } else {
+            format!("ipfs/{}", self.ipfs.unwrap().to_string())
+        }
+    }
+    /// parse cid from url
+    pub fn new(url: &Url) -> Self {
+        let mut ipfs = Ok(None);
+        let mut arweave = Ok(None);
+
+        Self::visit_url(url, |s| {
+            if let Some(c) = Self::try_ipfs(s) {
+                Self::advance_heuristic(&mut ipfs, c);
+            }
+
+            if let Some(t) = Self::try_arweave(s) {
+                Self::advance_heuristic(&mut arweave, t);
+            }
+        });
+
+        Self {
+            ipfs: ipfs.ok().flatten(),
+            arweave: arweave.ok().flatten(),
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ extern crate diesel_migrations;
 pub extern crate chrono;
 pub extern crate clap;
 
+pub mod assets;
 pub mod db;
 pub mod error;
 pub mod hash;

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -24,6 +24,8 @@ percent-encoding = "2.1.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.70"
 thiserror = "1.0.30"
+base64 = "0.13.0"
+
 [dependencies.indexer-core]
 package = "metaplex-indexer-core"
 version = "=0.1.0"

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -24,7 +24,6 @@ percent-encoding = "2.1.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.70"
 thiserror = "1.0.30"
-
 [dependencies.indexer-core]
 package = "metaplex-indexer-core"
 version = "=0.1.0"

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -164,13 +164,13 @@ impl Nft {
     pub fn image(&self) -> String {
         let assets_cdn = "https://assets.holaplex.com";
         let asset = AssetIdentifier::new(&Url::parse(&self.image).unwrap());
-        if asset.arweave.is_some() {
+        if asset.arweave.is_some() && asset.ipfs.is_none() {
             format!(
                 "{}/arweave/{}",
                 assets_cdn,
                 Base64Display::with_config(&asset.arweave.unwrap().0, base64::URL_SAFE_NO_PAD)
             )
-        } else if asset.ipfs.is_some() {
+        } else if asset.ipfs.is_some() && asset.arweave.is_none() {
             format!("{}/ipfs/{}", assets_cdn, asset.ipfs.unwrap())
         } else {
             String::from(&self.image)

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -1,4 +1,7 @@
+use base64::display::Base64Display;
+use indexer_core::assets::AssetIdentifier;
 use objects::{bid_receipt::BidReceipt, listing_receipt::ListingReceipt};
+use reqwest::Url;
 
 use super::prelude::*;
 
@@ -158,8 +161,20 @@ impl Nft {
         &self.description
     }
 
-    pub fn image(&self) -> &str {
-        &self.image
+    pub fn image(&self) -> String {
+        let assets_cdn = "https://assets.holaplex.com";
+        let asset = AssetIdentifier::new(&Url::parse(&self.image).unwrap());
+        if asset.arweave.is_some() {
+            format!(
+                "{}/arweave/{}",
+                assets_cdn,
+                Base64Display::with_config(&asset.arweave.unwrap().0, base64::URL_SAFE_NO_PAD)
+            )
+        } else if asset.ipfs.is_some() {
+            format!("{}/ipfs/{}", assets_cdn, asset.ipfs.unwrap())
+        } else {
+            String::from(&self.image)
+        }
     }
 
     pub async fn creators(&self, ctx: &AppContext) -> FieldResult<Vec<NftCreator>> {

--- a/crates/graphql/src/schema/query_root.rs
+++ b/crates/graphql/src/schema/query_root.rs
@@ -1,4 +1,4 @@
-use indexer_core::{assets::AssetIdentifier, db::queries};
+use indexer_core::db::queries;
 use objects::{
     auction_house::AuctionHouse,
     creator::Creator,
@@ -10,7 +10,6 @@ use objects::{
     storefront::{Storefront, StorefrontColumns},
     wallet::Wallet,
 };
-use reqwest::Url;
 use scalars::PublicKey;
 use tables::{
     auction_caches, auction_datas, auction_datas_ext, metadata_jsons, metadatas,
@@ -176,14 +175,7 @@ impl QueryRoot {
             .load(&conn)
             .context("Failed to load metadata")?;
 
-        Ok(rows.pop().map(|mut n| {
-            n.image = Some(format!(
-                "https://assets.holaplex.com/{}",
-                AssetIdentifier::new(&Url::parse(&n.image.unwrap_or(String::new())).unwrap())
-                    .get_cid_with_svc()
-            ));
-            n.into()
-        }))
+        Ok(rows.pop().map(Into::into))
     }
 
     fn storefronts(&self, context: &AppContext) -> FieldResult<Vec<Storefront>> {

--- a/crates/indexer/src/http/client.rs
+++ b/crates/indexer/src/http/client.rs
@@ -1,13 +1,10 @@
 use std::sync::Arc;
 
 use cid::Cid;
+use indexer_core::assets::ArTxid;
 use reqwest::Url;
 
 use crate::{db::Pool, prelude::*};
-
-/// An Arweave transaction ID
-#[derive(Debug, Clone, Copy)]
-pub struct ArTxid(pub [u8; 32]);
 
 /// Wrapper for handling networking logic
 #[derive(Debug)]

--- a/crates/indexer/src/http/metadata_json.rs
+++ b/crates/indexer/src/http/metadata_json.rs
@@ -5,6 +5,7 @@ use std::{
 
 use cid::Cid;
 use indexer_core::{
+    assets::AssetIdentifier,
     db::{
         insert_into,
         models::{
@@ -21,82 +22,8 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{client::ArTxid, Client};
+use super::Client;
 use crate::prelude::*;
-
-#[derive(Debug, Clone, Copy)]
-struct AssetIdentifier {
-    ipfs: Option<Cid>,
-    arweave: Option<ArTxid>,
-}
-
-impl AssetIdentifier {
-    fn visit_url(url: &Url, mut f: impl FnMut(&str)) {
-        Some(url.scheme())
-            .into_iter()
-            .chain(url.domain().into_iter().flat_map(|s| s.split('.')))
-            .chain(Some(url.username()))
-            .chain(url.password())
-            .chain(Some(url.path()))
-            .chain(url.path_segments().into_iter().flatten())
-            .chain(url.query())
-            .chain(url.fragment().into_iter().flat_map(|s| s.split('/')))
-            .for_each(&mut f);
-
-        url.query_pairs().for_each(|(k, v)| {
-            f(k.as_ref());
-            f(v.as_ref());
-        });
-    }
-
-    fn try_ipfs(s: &str) -> Option<Cid> {
-        s.try_into().ok()
-    }
-
-    fn try_arweave(s: &str) -> Option<ArTxid> {
-        [
-            base64::URL_SAFE,
-            base64::URL_SAFE_NO_PAD,
-            base64::STANDARD,
-            base64::STANDARD_NO_PAD,
-        ]
-        .into_iter()
-        .find_map(|c| {
-            base64::decode_config(s.as_bytes(), c)
-                .ok()
-                .and_then(|v| v.try_into().ok())
-                .map(ArTxid)
-        })
-    }
-
-    fn advance_heuristic<T>(state: &mut Result<Option<T>, ()>, value: T) {
-        match state {
-            Ok(None) => *state = Ok(Some(value)),
-            Ok(Some(_)) => *state = Err(()),
-            Err(()) => (),
-        }
-    }
-
-    fn new(url: &Url) -> Self {
-        let mut ipfs = Ok(None);
-        let mut arweave = Ok(None);
-
-        Self::visit_url(url, |s| {
-            if let Some(c) = Self::try_ipfs(s) {
-                Self::advance_heuristic(&mut ipfs, c);
-            }
-
-            if let Some(t) = Self::try_arweave(s) {
-                Self::advance_heuristic(&mut arweave, t);
-            }
-        });
-
-        Self {
-            ipfs: ipfs.ok().flatten(),
-            arweave: arweave.ok().flatten(),
-        }
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug)]
 struct File {


### PR DESCRIPTION
- moved `AssetIdentifier` from `indexer/http/metadata_json` to `indexer-core/assets.rs`
- added function to return detected service and Cid in `AssetsIdentifier`
- implemented transforming url to `assets.holaplex.com` in graphql