### PR TITLE
switch to inner join for receipts

### DIFF
--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -63,9 +63,7 @@ pub fn list(
         .inner_join(
             token_accounts::table.on(metadatas::mint_address.eq(token_accounts::mint_address)),
         )
-        .left_outer_join(
-            listing_receipts::table.on(metadatas::address.eq(listing_receipts::metadata)),
-        )
+        .inner_join(listing_receipts::table.on(metadatas::address.eq(listing_receipts::metadata)))
         .into_boxed();
 
     if let Some(attributes) = attributes {

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -63,7 +63,6 @@ pub fn list(
         .inner_join(
             token_accounts::table.on(metadatas::mint_address.eq(token_accounts::mint_address)),
         )
-        .inner_join(listing_receipts::table.on(metadatas::address.eq(listing_receipts::metadata)))
         .into_boxed();
 
     if let Some(attributes) = attributes {
@@ -95,6 +94,9 @@ pub fn list(
 
     if let Some(listed) = listed {
         query = query
+            .inner_join(
+                listing_receipts::table.on(metadatas::address.eq(listing_receipts::metadata)),
+            )
             .filter(listing_receipts::auction_house.eq(any(listed)))
             .filter(listing_receipts::purchase_receipt.is_null())
             .filter(listing_receipts::canceled_at.is_null())


### PR DESCRIPTION
In the future as we develop more and more complex queries, we have to remember to test with larger datasets. The dark magic of the postgres query planner operates much different when it is examining a set of 3 or 30,000. 

When querying on this creator `8CWKUvr9KDqFZww2q3xurag3FdjqmAUEVT97hX3ZBYz9` , this query never returns. I think its because the inner joins have so many rows that adding a row for every receipt record causes the final table to be far too large. 


Do we need multiple receipts per NFT in this query? It qualifies as listed with just 1 that matches the filters correct?
