### PR TITLE
Left Join for Attributes Filter on NFTs

### DIFF
--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -66,6 +66,7 @@ pub fn list(
         .left_outer_join(
             listing_receipts::table.on(metadatas::address.eq(listing_receipts::metadata)),
         )
+        .left_outer_join(attributes::table.on(metadatas::address.eq(attributes::metadata_address)))
         .into_boxed();
 
     if let Some(attributes) = attributes {
@@ -73,15 +74,11 @@ pub fn list(
             attributes
                 .into_iter()
                 .fold(query, |acc, AttributeFilter { trait_type, values }| {
-                    let sub = attributes::table
-                        .select(attributes::metadata_address)
-                        .filter(
-                            attributes::trait_type
-                                .eq(trait_type)
-                                .and(attributes::value.eq(any(values))),
-                        );
-
-                    acc.filter(metadatas::address.eq(any(sub)))
+                    acc.filter(
+                        attributes::trait_type
+                            .eq(trait_type)
+                            .and(attributes::value.eq(any(values))),
+                    )
                 });
     }
 


### PR DESCRIPTION
### Changes
- Instead of sub query left_outer join the attributes table and add filter to composite view of the data. The distinct tosses out dups and returns single copy of the nft.

Adding more filters further narrows the data set and making the query faster.

<img width="1156" alt="Screen Shot 2022-03-11 at 6 55 51 AM" src="https://user-images.githubusercontent.com/2388118/157892581-cd1f5ffa-f862-450a-8e2d-54b3e57a0ac5.png">
