### PR TITLE
Index Metadata Creator Position and First Verified Creator on Attributes

### DIFF
--- a/crates/core/migrations/2022-03-12-001120_add_position_to_metadata_creators/down.sql
+++ b/crates/core/migrations/2022-03-12-001120_add_position_to_metadata_creators/down.sql
@@ -1,0 +1,2 @@
+alter table metadata_creators
+drop column position;

--- a/crates/core/migrations/2022-03-12-001120_add_position_to_metadata_creators/up.sql
+++ b/crates/core/migrations/2022-03-12-001120_add_position_to_metadata_creators/up.sql
@@ -1,0 +1,2 @@
+alter table metadata_creators
+add column position int null;

--- a/crates/core/migrations/2022-03-12-003003_add_first_verified_creator_to_attributes/down.sql
+++ b/crates/core/migrations/2022-03-12-003003_add_first_verified_creator_to_attributes/down.sql
@@ -1,0 +1,4 @@
+alter table attributes
+drop column first_verified_creator;
+
+drop index if exists attributes_first_verified_creator_idx;

--- a/crates/core/migrations/2022-03-12-003003_add_first_verified_creator_to_attributes/up.sql
+++ b/crates/core/migrations/2022-03-12-003003_add_first_verified_creator_to_attributes/up.sql
@@ -1,0 +1,5 @@
+alter table attributes
+add column first_verified_creator varchar(48) null;
+
+create index if not exists attributes_first_verified_creator_idx
+on attributes (first_verified_creator);

--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -146,6 +146,8 @@ pub struct MetadataCreator<'a> {
     pub share: i32,
     /// Whether this creator has verified this metadata
     pub verified: bool,
+    /// position of creator in metadata creator array
+    pub position: Option<i32>,
 }
 
 /// A row in the `token_accounts` table
@@ -341,6 +343,8 @@ pub struct MetadataAttributeWrite<'a> {
     pub value: Option<Cow<'a, str>>,
     /// Attribute trait type
     pub trait_type: Option<Cow<'a, str>>,
+    /// Address of metadata first verified creator
+    pub first_verified_creator: Option<Cow<'a, str>>,
 }
 
 /// A row in the `attributes` table
@@ -354,6 +358,8 @@ pub struct MetadataAttribute<'a> {
     pub trait_type: Option<Cow<'a, str>>,
     /// Attribute generated id
     pub id: Cow<'a, uuid::Uuid>,
+    /// Address of metadata first verified creator
+    pub first_verified_creator: Option<Cow<'a, str>>,
 }
 
 /// A row in the `metadata_collections` table

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -7,6 +7,7 @@ table! {
         value -> Nullable<Text>,
         trait_type -> Nullable<Text>,
         id -> Uuid,
+        first_verified_creator -> Nullable<Varchar>,
     }
 }
 
@@ -209,6 +210,7 @@ table! {
         creator_address -> Varchar,
         share -> Int4,
         verified -> Bool,
+        position -> Nullable<Int4>,
     }
 }
 

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -50,31 +50,13 @@ impl<'a> TryFrom<models::MetadataAttribute<'a>> for NftAttribute {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, GraphQLObject)]
 pub struct NftCreator {
     pub address: String,
     pub metadata_address: String,
     pub share: i32,
     pub verified: bool,
-}
-
-#[graphql_object(Context = AppContext)]
-impl NftCreator {
-    pub fn address(&self) -> &str {
-        &self.address
-    }
-
-    pub fn metadata_address(&self) -> &str {
-        &self.metadata_address
-    }
-
-    pub fn share(&self) -> i32 {
-        self.share
-    }
-
-    pub fn verified(&self) -> bool {
-        self.verified
-    }
+    pub position: Option<i32>,
 }
 
 impl<'a> From<models::MetadataCreator<'a>> for NftCreator {
@@ -84,6 +66,7 @@ impl<'a> From<models::MetadataCreator<'a>> for NftCreator {
             metadata_address,
             share,
             verified,
+            position,
         }: models::MetadataCreator,
     ) -> Self {
         Self {
@@ -91,6 +74,7 @@ impl<'a> From<models::MetadataCreator<'a>> for NftCreator {
             metadata_address: metadata_address.into_owned(),
             share,
             verified,
+            position,
         }
     }
 }

--- a/crates/indexer/src/accountsdb/accounts/metadata.rs
+++ b/crates/indexer/src/accountsdb/accounts/metadata.rs
@@ -55,19 +55,17 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
         .await
         .context("Failed to dispatch metadata JSON job")?;
 
-    for (position, creator) in meta
-        .data
-        .creators
-        .iter()
-        .flatten()
-        .enumerate()
-    {
+    for (position, creator) in meta.data.creators.iter().flatten().enumerate() {
         let row = MetadataCreator {
             metadata_address: Owned(addr.clone()),
             creator_address: Owned(bs58::encode(creator.address).into_string()),
             share: creator.share.into(),
             verified: creator.verified,
-            position: Some(position.try_into().context("Position was too big to store")?),
+            position: Some(
+                position
+                    .try_into()
+                    .context("Position was too big to store")?,
+            ),
         };
 
         client

--- a/crates/indexer/src/accountsdb/accounts/metadata.rs
+++ b/crates/indexer/src/accountsdb/accounts/metadata.rs
@@ -30,7 +30,7 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
     let first_verified_creator: Option<Pubkey> = meta
         .data
         .creators
-        .clone()
+        .as_ref()
         .and_then(|creators| creators.iter().find(|c| c.verified).map(|c| c.address));
 
     client
@@ -58,8 +58,8 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
     for (position, creator) in meta
         .data
         .creators
-        .unwrap_or_else(Vec::new)
         .iter()
+        .flatten()
         .enumerate()
     {
         let row = MetadataCreator {
@@ -67,7 +67,7 @@ pub(crate) async fn process(client: &Client, key: Pubkey, meta: MetadataAccount)
             creator_address: Owned(bs58::encode(creator.address).into_string()),
             share: creator.share.into(),
             verified: creator.verified,
-            position: Some(position.try_into().unwrap()),
+            position: Some(position.try_into().context("Position was too big to store")?),
         };
 
         client

--- a/crates/indexer/src/accountsdb/client.rs
+++ b/crates/indexer/src/accountsdb/client.rs
@@ -132,11 +132,16 @@ impl Client {
     pub async fn dispatch_metadata_json(
         &self,
         meta_address: Pubkey,
+        first_verified_creator: Option<Pubkey>,
         uri: String,
     ) -> Result<(), indexer_rabbitmq::Error> {
         self.http
             .metadata_json
-            .write(http_indexer::MetadataJson { meta_address, uri })
+            .write(http_indexer::MetadataJson {
+                meta_address,
+                uri,
+                first_verified_creator,
+            })
             .await
     }
 

--- a/crates/indexer/src/http/metadata_json.rs
+++ b/crates/indexer/src/http/metadata_json.rs
@@ -475,6 +475,14 @@ pub async fn process<'a>(
     if is_present {
         debug!("Skipping already-indexed metadata JSON for {}", meta_key);
 
+        // NOTE: For future reference, this introduces a situation with non-
+        //       idempotent updates.  It is possible that with job retries, a
+        //       sequence of two metadata jobs with differing values for
+        //       first_verified_creator can write the wrong value.  If the first
+        //       job fails, it will be eventually requeued after the second job.
+        //       If the second job subsequently succeeds, then this reprocess
+        //       function will be called by the first job and the first
+        //       verified creator will be updated to an out-of-date value.
         reprocess_attributes(client, addr, first_verified_creator).await?;
 
         return Ok(());

--- a/crates/indexer/src/http/mod.rs
+++ b/crates/indexer/src/http/mod.rs
@@ -19,9 +19,13 @@ pub trait Process: Entity {
 #[async_trait::async_trait]
 impl Process for MetadataJson {
     async fn process(self, client: &Client) -> Result<()> {
-        let MetadataJson { meta_address, uri } = self;
+        let MetadataJson {
+            meta_address,
+            first_verified_creator,
+            uri,
+        } = self;
 
-        metadata_json::process(client, meta_address, uri).await
+        metadata_json::process(client, meta_address, first_verified_creator, uri).await
     }
 }
 

--- a/crates/rabbitmq/src/http_indexer.rs
+++ b/crates/rabbitmq/src/http_indexer.rs
@@ -51,6 +51,8 @@ pub struct MetadataJson {
     pub meta_address: Pubkey,
     /// The URI to retrieve the file from
     pub uri: String,
+    /// possibly the first verified creator
+    pub first_verified_creator: Option<Pubkey>,
 }
 
 impl Entity for MetadataJson {


### PR DESCRIPTION
### Changes

- Index the position of the creator in the metadata creators array. Paying out royalties for ah sales require that the position of the accounts being payed out with sales matches that of the metadata so we need to track the position of the creator in our index.
- Index the first verified creator on the attributes to eliminate doing a nest loop on the query when finding attribute groups for a creator. 