### PR TITLE
adding dynamic cdn selection using md5, added documentation in nft im…

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ ARWEAVE_URL=https://arweave.net/
 IPFS_CDN=https://ipfs.cache.holaplex.com/
 ARWEAVE_CDN=https://arweave.net/
 ASSET_PROXY_ENDPOINT=https://assets.holaplex.com/
-ASSET_PROXY_COUNT=1
+ASSET_PROXY_COUNT=5

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 ARWEAVE_URL=https://arweave.net/
 IPFS_CDN=https://ipfs.cache.holaplex.com/
 ARWEAVE_CDN=https://arweave.net/
-ASSET_PROXY_ENDPOINT=https://assets.holaplex.com/
+ASSET_PROXY_ENDPOINT=https://assets[n].holaplex.com/
 ASSET_PROXY_COUNT=5

--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ ARWEAVE_URL=https://arweave.net/
 IPFS_CDN=https://ipfs.cache.holaplex.com/
 ARWEAVE_CDN=https://arweave.net/
 ASSET_PROXY_ENDPOINT=https://assets.holaplex.com/
+ASSET_PROXY_COUNT=1

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.70"
 thiserror = "1.0.30"
 base64 = "0.13.0"
+md5 = "0.7.0"
 
 [dependencies.indexer-core]
 package = "metaplex-indexer-core"

--- a/crates/graphql/src/main.rs
+++ b/crates/graphql/src/main.rs
@@ -29,6 +29,9 @@ struct Opts {
 
     #[clap(long, env)]
     asset_proxy_endpoint: String,
+
+    #[clap(long, env)]
+    asset_proxy_count: u8,
 }
 
 fn graphiql(uri: String) -> impl Fn() -> HttpResponse + Clone {
@@ -68,6 +71,7 @@ fn graphql(
 
 pub(crate) struct SharedData {
     pub asset_proxy_endpoint: String,
+    pub asset_proxy_count: u8,
     pub twitter_bearer_token: String,
 }
 
@@ -77,11 +81,13 @@ fn main() {
             server: ServerOpts { port },
             twitter_bearer_token,
             asset_proxy_endpoint,
+            asset_proxy_count,
         } = Opts::parse();
 
         let twitter_bearer_token = twitter_bearer_token.unwrap_or_else(String::new);
         let shared = Arc::new(SharedData {
             asset_proxy_endpoint,
+            asset_proxy_count,
             twitter_bearer_token,
         });
 

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -161,18 +161,18 @@ impl Nft {
 
             let rem = md5::compute(&cid).to_vec()[0].rem_euclid(cdn_count);
             let assets_cdn = if rem == 0 {
-                assets_cdn.to_string()
+                assets_cdn.replace("[n]", "")
             } else {
-                assets_cdn.replace("assets", &format!("assets{}", rem))
+                assets_cdn.replace("[n]", &rem.to_string())
             };
             format!("{}arweave/{}?width={}", assets_cdn, cid, width as i32)
         } else if asset.ipfs.is_some() && asset.arweave.is_none() {
             let cid = asset.ipfs.unwrap().to_string();
             let rem = md5::compute(&cid).to_vec()[0].rem_euclid(cdn_count);
             let assets_cdn = if rem == 0 {
-                assets_cdn.to_string()
+                assets_cdn.replace("[n]", "")
             } else {
-                assets_cdn.replace("assets", &format!("assets{}", rem))
+                assets_cdn.replace("[n]", &rem.to_string())
             };
             format!("{}ipfs/{}?width={}", assets_cdn, cid, width as i32)
         } else {

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -160,19 +160,19 @@ impl Nft {
                     .to_string();
 
             let rem = md5::compute(&cid).to_vec()[0].rem_euclid(cdn_count);
-            let assets_cdn = if rem != 0 {
-                assets_cdn.replace("assets", &format!("assets{}", rem))
-            } else {
+            let assets_cdn = if rem == 0 {
                 assets_cdn.to_string()
+            } else {
+                assets_cdn.replace("assets", &format!("assets{}", rem))
             };
             format!("{}arweave/{}?width={}", assets_cdn, cid, width as i32)
         } else if asset.ipfs.is_some() && asset.arweave.is_none() {
             let cid = asset.ipfs.unwrap().to_string();
             let rem = md5::compute(&cid).to_vec()[0].rem_euclid(cdn_count);
-            let assets_cdn = if rem != 0 {
-                assets_cdn.replace("assets", &format!("assets{}", rem))
-            } else {
+            let assets_cdn = if rem == 0 {
                 assets_cdn.to_string()
+            } else {
+                assets_cdn.replace("assets", &format!("assets{}", rem))
             };
             format!("{}ipfs/{}?width={}", assets_cdn, cid, width as i32)
         } else {

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -165,7 +165,7 @@ impl Nft {
             } else {
                 assets_cdn.to_string()
             };
-            format!("{}/arweave/{}?width={}", assets_cdn, cid, width as i32)
+            format!("{}arweave/{}?width={}", assets_cdn, cid, width as i32)
         } else if asset.ipfs.is_some() && asset.arweave.is_none() {
             let cid = asset.ipfs.unwrap().to_string();
             let rem = md5::compute(&cid).to_vec()[0].rem_euclid(cdn_count);
@@ -174,7 +174,7 @@ impl Nft {
             } else {
                 assets_cdn.to_string()
             };
-            format!("{}/ipfs/{}?width={}", assets_cdn, cid, width as i32)
+            format!("{}ipfs/{}?width={}", assets_cdn, cid, width as i32)
         } else {
             String::from(&self.image)
         }


### PR DESCRIPTION
- Added dynamic CDN selection
- Added some docs on the graphql image width parameter
- added `ASSET_PROXY_COUNT=5` to `.env` file

when `ASSET_PROXY_COUNT` is set to 1, asset endpoint url will be always `assets.holaplex.com`.
If raised, it will start adding a number to the endponit url: Ex `assets3.holaplex.com`