### PR TITLE
changing the default image size in graphql to 400px 

### DIFF
--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -21,6 +21,10 @@ pub struct AssetIdentifier {
 pub enum ImageSize {
     /// image natural size
     Original = 0,
+    /// tiny image
+    Tiny = 100,
+    /// extra small image
+    XSmall = 400,
     /// small image
     Small = 600,
     /// medium image

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -1,4 +1,5 @@
 //! Query utilities for looking up  metadatas
+
 use diesel::prelude::*;
 
 use crate::{
@@ -112,11 +113,10 @@ pub fn list(
         ))
         .filter(token_accounts::amount.eq(1))
         .distinct()
-        .order_by(metadatas::name.desc())
         .limit(limit)
         .offset(offset)
         .load(conn)
         .context("failed to load nft(s)")?;
 
-    Ok(rows.into_iter().map(Into::into).collect())
+    Ok(rows)
 }

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -146,7 +146,7 @@ impl Nft {
     }
 
     #[graphql(arguments(width(
-        description = "Image width possible values are:\n- 0 (Original size)\n-100 (Tiny)\n- 400 (XSmall)\n- 600 (Small)\n- 800 (Medium)\n- 1400 (Large)\n\n Any other value will return the original image size.\n\n If no value is provided, it will return XSmall"
+        description = "Image width possible values are:\n- 0 (Original size)\n- 100 (Tiny)\n- 400 (XSmall)\n- 600 (Small)\n- 800 (Medium)\n- 1400 (Large)\n\n Any other value will return the original image size.\n\n If no value is provided, it will return XSmall"
     ),))]
     pub fn image(&self, width: Option<i32>, ctx: &AppContext) -> String {
         let width = ImageSize::from(width.unwrap_or(ImageSize::XSmall as i32));

--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -146,10 +146,10 @@ impl Nft {
     }
 
     #[graphql(arguments(width(
-        description = "Image width possible values are:\n- 0 (Original size)\n- 600 (Small)\n- 800 (Medium)\n- 1400 (Large)\n\n Any other value will return the original image size.\n\n If no value is provided, it will return width 800"
+        description = "Image width possible values are:\n- 0 (Original size)\n-100 (Tiny)\n- 400 (XSmall)\n- 600 (Small)\n- 800 (Medium)\n- 1400 (Large)\n\n Any other value will return the original image size.\n\n If no value is provided, it will return XSmall"
     ),))]
     pub fn image(&self, width: Option<i32>, ctx: &AppContext) -> String {
-        let width = ImageSize::from(width.unwrap_or(ImageSize::Medium as i32));
+        let width = ImageSize::from(width.unwrap_or(ImageSize::XSmall as i32));
         let cdn_count = ctx.shared.asset_proxy_count;
         let assets_cdn = &ctx.shared.asset_proxy_endpoint;
         let asset = AssetIdentifier::new(&Url::parse(&self.image).unwrap());


### PR DESCRIPTION
- Default image size returned is now 400px when no value is provided in graphql
- Order BY removed from [crates/core/src/db/queries/metadatas.rs](https://github.com/holaplex/solana-indexer/commit/00a0639b0b3dbf3b0c82962d48c6def8339ea328#diff-9a080dfe669d746b43c043fc557a06d5add886b23833af6daa7d80745c432520) by @ray-kast 