### PR TITLE
Collection Preview, Order NFT Creators, Fix Attribute Filters Query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,6 +2949,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "dataloader",
+ "itertools",
  "juniper",
  "md5",
  "metaplex-indexer-core",

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -14,8 +14,12 @@ pub mod tables {
 use std::env;
 
 pub use diesel::{
-    backend::Backend, insert_into, pg::upsert::excluded, query_dsl, result::Error, select,
-    serialize, sql_types, update, Queryable,
+    backend::Backend,
+    debug_query, insert_into,
+    pg::{upsert::excluded, Pg},
+    query_dsl,
+    result::Error,
+    select, serialize, sql_query, sql_types, update, Queryable,
 };
 use diesel::{pg, r2d2};
 pub use diesel_full_text_search::{

--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -5,6 +5,7 @@
 use std::borrow::Cow;
 
 use chrono::NaiveDateTime;
+use diesel::sql_types::{Bool, Int4, Nullable, Text, VarChar};
 
 use super::schema::{
     attributes, auction_caches, auction_datas, auction_datas_ext, auction_houses, bid_receipts,
@@ -223,30 +224,77 @@ pub struct Storefront<'a> {
 }
 
 /// Join of `metadatas` and `metadata_jsons` for an NFT
-#[derive(Debug, Clone, Queryable)]
+#[derive(Debug, Clone, Queryable, QueryableByName)]
 pub struct Nft {
     // Table metadata
     /// The address of this account
+    #[sql_type = "VarChar"]
     pub address: String,
 
     /// The name of this item
+    #[sql_type = "Text"]
     pub name: String,
 
     /// The royalty percentage of the creator, in basis points (0.01%, values
     /// range from 0-10,000)
+    #[sql_type = "Int4"]
     pub seller_fee_basis_points: i32,
 
     /// The token address for this item
+    #[sql_type = "VarChar"]
     pub mint_address: String,
 
     /// True if this item is in the secondary market.  Immutable once set.
+    #[sql_type = "Bool"]
     pub primary_sale_happened: bool,
 
     // Table metadata_json
     /// Metadata description
+    #[sql_type = "Nullable<Text>"]
     pub description: Option<String>,
 
     /// Metadata Image url
+    #[sql_type = "Nullable<Text>"]
+    pub image: Option<String>,
+}
+
+/// Join of `metadatas` `metadata_jsons` `store_creators` for an collection preview
+#[derive(Debug, Clone, Queryable, QueryableByName)]
+pub struct SampleNft {
+    // Table store_creators
+    /// The store creators address
+    #[sql_type = "VarChar"]
+    pub creator_address: String,
+
+    // Table metadata
+    /// The address of this account
+    #[sql_type = "VarChar"]
+    pub address: String,
+
+    /// The name of this item
+    #[sql_type = "Text"]
+    pub name: String,
+
+    /// The royalty percentage of the creator, in basis points (0.01%, values
+    /// range from 0-10,000)
+    #[sql_type = "Int4"]
+    pub seller_fee_basis_points: i32,
+
+    /// The token address for this item
+    #[sql_type = "VarChar"]
+    pub mint_address: String,
+
+    /// True if this item is in the secondary market.  Immutable once set.
+    #[sql_type = "Bool"]
+    pub primary_sale_happened: bool,
+
+    // Table metadata_json
+    /// Metadata description
+    #[sql_type = "Nullable<Text>"]
+    pub description: Option<String>,
+
+    /// Metadata Image url
+    #[sql_type = "Nullable<Text>"]
     pub image: Option<String>,
 }
 
@@ -571,8 +619,9 @@ pub struct PurchaseReceipt<'a> {
 }
 
 /// A row in the `store_creators` table
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Queryable, Insertable, AsChangeset, QueryableByName)]
 #[diesel(treat_none_as_null = true)]
+#[table_name = "store_creators"]
 pub struct StoreCreator<'a> {
     /// Store Config account address
     pub store_config_address: Cow<'a, str>,

--- a/crates/core/src/db/queries/metadatas.rs
+++ b/crates/core/src/db/queries/metadatas.rs
@@ -56,35 +56,33 @@ pub fn list(
     }: ListQueryOptions,
 ) -> Result<Vec<Nft>> {
     if creators.is_some() && attributes.is_none() && owners.is_none() && listed.is_none() {
-        if let Some(creators) = creators {
-            let query = metadatas::table
-                .inner_join(
-                    metadata_creators::table
-                        .on(metadatas::address.eq(metadata_creators::metadata_address)),
-                )
-                .inner_join(
-                    metadata_jsons::table
-                        .on(metadatas::address.eq(metadata_jsons::metadata_address)),
-                )
-                .filter(metadata_creators::creator_address.eq(any(creators)))
-                .filter(metadata_creators::verified.eq(true))
-                .select((
-                    metadatas::address,
-                    metadatas::name,
-                    metadatas::seller_fee_basis_points,
-                    metadatas::mint_address,
-                    metadatas::primary_sale_happened,
-                    metadata_jsons::description,
-                    metadata_jsons::image,
-                ))
-                .distinct()
-                .limit(limit)
-                .offset(offset);
+        let query = metadatas::table
+            .inner_join(
+                metadata_creators::table
+                    .on(metadatas::address.eq(metadata_creators::metadata_address)),
+            )
+            .inner_join(
+                metadata_jsons::table.on(metadatas::address.eq(metadata_jsons::metadata_address)),
+            )
+            .filter(metadata_creators::creator_address.eq(any(creators.unwrap_or_else(Vec::new))))
+            .filter(metadata_creators::verified.eq(true))
+            .select((
+                metadatas::address,
+                metadatas::name,
+                metadatas::seller_fee_basis_points,
+                metadatas::mint_address,
+                metadatas::primary_sale_happened,
+                metadata_jsons::description,
+                metadata_jsons::image,
+            ))
+            .distinct()
+            .order(metadatas::address.asc())
+            .limit(limit)
+            .offset(offset);
 
-            let rows: Vec<Nft> = query.load(conn).context("failed to load nft(s)")?;
+        let rows: Vec<Nft> = query.load(conn).context("failed to load nft(s)")?;
 
-            return Ok(rows.into_iter().map(Into::into).collect());
-        }
+        return Ok(rows.into_iter().map(Into::into).collect());
     }
 
     let mut query = metadatas::table
@@ -145,6 +143,7 @@ pub fn list(
             metadata_jsons::image,
         ))
         .distinct()
+        .order(metadatas::address.asc())
         .limit(limit)
         .offset(offset)
         .load(conn)

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -21,7 +21,7 @@ dataloader = "0.14.0"
 itertools = "0.10.2"
 juniper = "0.15.9"
 percent-encoding = "2.1.0"
-reqwest = { version = "0.11.6", features =["json"] }
+reqwest = { version = "0.11.6", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.70"
 thiserror = "1.0.30"

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -18,9 +18,10 @@ actix-cors = "0.6.0-beta.8"
 actix-web = "4.0.0-beta.21"
 async-trait = "0.1"
 dataloader = "0.14.0"
-reqwest = { version = "0.11.6", features =["json"] }
+itertools = "0.10.2"
 juniper = "0.15.9"
 percent-encoding = "2.1.0"
+reqwest = { version = "0.11.6", features =["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.70"
 thiserror = "1.0.30"

--- a/crates/graphql/src/schema/context.rs
+++ b/crates/graphql/src/schema/context.rs
@@ -29,6 +29,7 @@ pub struct AppContext {
     pub listing_receipts_loader: Loader<PublicKey<Nft>, Vec<ListingReceipt>>,
     pub bid_receipts_loader: Loader<PublicKey<Nft>, Vec<BidReceipt>>,
     pub store_creator_loader: Loader<PublicKey<StoreConfig>, Vec<StoreCreator>>,
+    pub collection_loader: Loader<PublicKey<StoreCreator>, Vec<Nft>>,
 }
 
 impl juniper::Context for AppContext {}
@@ -48,7 +49,8 @@ impl AppContext {
             storefront_loader: Loader::new(batcher.clone()),
             listing_receipts_loader: Loader::new(batcher.clone()),
             bid_receipts_loader: Loader::new(batcher.clone()),
-            store_creator_loader: Loader::new(batcher),
+            store_creator_loader: Loader::new(batcher.clone()),
+            collection_loader: Loader::new(batcher),
             db_pool,
             shared,
         }

--- a/crates/graphql/src/schema/dataloaders/collection.rs
+++ b/crates/graphql/src/schema/dataloaders/collection.rs
@@ -1,0 +1,65 @@
+use indexer_core::db::{
+    sql_query,
+    sql_types::{Array, Text},
+};
+use objects::{nft::Nft, store_creator::StoreCreator};
+use scalars::PublicKey;
+
+use super::prelude::*;
+
+#[async_trait]
+impl TryBatchFn<PublicKey<StoreCreator>, Vec<Nft>> for Batcher {
+    async fn load(
+        &mut self,
+        addresses: &[PublicKey<StoreCreator>],
+    ) -> TryBatchMap<PublicKey<StoreCreator>, Vec<Nft>> {
+        let conn = self.db()?;
+
+        let rows: Vec<models::SampleNft> = sql_query(
+                "SELECT sample_metadatas.creator_address, sample_metadatas.address, sample_metadatas.name, sample_metadatas.seller_fee_basis_points, sample_metadatas.mint_address, sample_metadatas.primary_sale_happened, sample_metadatas.description, sample_metadatas.image
+                FROM store_creators
+                JOIN LATERAL (
+                    SELECT metadatas.address AS address, metadatas.name AS name, metadatas.seller_fee_basis_points AS seller_fee_basis_points, metadatas.mint_address AS mint_address, metadatas.primary_sale_happened AS primary_sale_happened, metadata_jsons.description AS description, metadata_jsons.image AS image, store_creators.creator_address AS creator_address
+                    FROM metadatas
+                    INNER JOIN metadata_jsons ON (metadatas.address = metadata_jsons.metadata_address)
+                    INNER JOIN metadata_creators ON (metadatas.address = metadata_creators.metadata_address)
+                    WHERE metadata_creators.creator_address = store_creators.creator_address
+                    ORDER BY metadatas.address DESC
+                    LIMIT 3
+                ) AS sample_metadatas ON true
+                WHERE store_creators.creator_address = ANY($1);",
+        ).bind::<Array<Text>, _>(addresses)
+            .load(&conn)
+            .context("Failed to load collection preview(s)")?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |models::SampleNft {
+                     creator_address,
+                     address,
+                     name,
+                     seller_fee_basis_points,
+                     mint_address,
+                     primary_sale_happened,
+                     description,
+                     image,
+                 }| {
+                    (
+                        creator_address,
+                        models::Nft {
+                            address,
+                            name,
+                            seller_fee_basis_points,
+                            mint_address,
+                            primary_sale_happened,
+                            description,
+                            image,
+                        }
+                        .try_into(),
+                    )
+                },
+            )
+            .batch(addresses))
+    }
+}

--- a/crates/graphql/src/schema/dataloaders/mod.rs
+++ b/crates/graphql/src/schema/dataloaders/mod.rs
@@ -1,5 +1,6 @@
 pub mod auction_house;
 pub mod bid_receipt;
+pub mod collection;
 pub mod listing;
 pub mod listing_receipt;
 pub mod nft;

--- a/crates/graphql/src/schema/dataloaders/nft.rs
+++ b/crates/graphql/src/schema/dataloaders/nft.rs
@@ -34,6 +34,7 @@ impl TryBatchFn<PublicKey<Nft>, Vec<NftCreator>> for Batcher {
 
         let rows: Vec<models::MetadataCreator> = metadata_creators::table
             .filter(metadata_creators::metadata_address.eq(any(addresses)))
+            .order(metadata_creators::position.asc())
             .load(&conn)
             .context("Failed to load NFT creators")?;
 

--- a/crates/graphql/src/schema/objects/store_creator.rs
+++ b/crates/graphql/src/schema/objects/store_creator.rs
@@ -1,9 +1,28 @@
-use super::prelude::*;
+use super::{nft::Nft, prelude::*};
 
-#[derive(Debug, Clone, GraphQLObject)]
+#[derive(Debug, Clone)]
 pub struct StoreCreator {
     pub store_config_address: String,
     pub creator_address: String,
+}
+
+#[graphql_object(Context = AppContext)]
+impl StoreCreator {
+    pub fn store_config_address(&self) -> &str {
+        &self.store_config_address
+    }
+
+    pub fn creator_address(&self) -> &str {
+        &self.creator_address
+    }
+
+    pub async fn preview(&self, context: &AppContext) -> FieldResult<Vec<Nft>> {
+        context
+            .collection_loader
+            .load(self.creator_address.clone().into())
+            .await
+            .map_err(Into::into)
+    }
 }
 
 impl<'a> From<models::StoreCreator<'a>> for StoreCreator {


### PR DESCRIPTION
### Changes
- Add preview to creators object which returns 3 sample nfts for displaying collection previews.
- Order nft creators by position to match with metadata. Ah execute sale requires order of creators passed in matches that of the metadata.
- order by address to nfts query so limit offset pagination is consistent. (This should likely be name but there is no index? Result slower with name)
- Sort attribute trait types and values alphabetically