### PR TITLE
Fixups to indexer consumers.

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 ARWEAVE_URL=https://arweave.net/
 IPFS_CDN=https://ipfs.cache.holaplex.com/
 ARWEAVE_CDN=https://arweave.net/
+HTTP_INDEXER_TIMEOUT=10
 ASSET_PROXY_ENDPOINT=https://assets[n].holaplex.com/
 ASSET_PROXY_COUNT=5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1633,16 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2874,6 +2898,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "cid",
+ "crossbeam",
  "futures-util",
  "graph_program",
  "metaplex",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@ extern crate diesel;
 #[macro_use]
 extern crate diesel_migrations;
 
+pub extern crate ahash;
 pub extern crate chrono;
 pub extern crate clap;
 

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -43,6 +43,7 @@ required-features = ["http"]
 
 [dependencies]
 async-trait = "0.1.52"
+crossbeam = "0.8.1"
 futures-util = "0.3.21"
 num_cpus = "1.13.1"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/crates/indexer/src/bin/metaplex-indexer-http.rs
+++ b/crates/indexer/src/bin/metaplex-indexer-http.rs
@@ -1,6 +1,6 @@
 use indexer_core::{clap, prelude::*};
 use indexer_rabbitmq::http_indexer;
-use metaplex_indexer::http::Client;
+use metaplex_indexer::http::{Client, ClientArgs};
 
 #[derive(Debug, clap::Parser)]
 struct Args {
@@ -22,13 +22,8 @@ struct Args {
     /// the indexer.
     queue_suffix: Option<String>,
 
-    /// A valid base URL to use when fetching IPFS links
-    #[clap(long, env)]
-    ipfs_cdn: String,
-
-    /// A valid base URL to use when fetching Arweave links
-    #[clap(long, env)]
-    arweave_cdn: String,
+    #[clap(flatten)]
+    client: ClientArgs,
 }
 
 fn main() {
@@ -55,19 +50,11 @@ async fn run<E: Send + metaplex_indexer::http::Process + 'static>(
         sender,
         entity: _,
         queue_suffix,
-        ipfs_cdn,
-        arweave_cdn,
+        client,
     } = args;
 
     let conn = metaplex_indexer::amqp_connect(amqp_url).await?;
-    let client = Client::new_rc(
-        db,
-        ipfs_cdn.parse().context("Failed to parse IPFS CDN URL")?,
-        arweave_cdn
-            .parse()
-            .context("Failed to parse Arweave CDN URL")?,
-    )
-    .context("Failed to construct Client")?;
+    let client = Client::new_rc(db, client, &params).context("Failed to construct Client")?;
 
     let queue_type = http_indexer::QueueType::<E>::new(&sender, queue_suffix.as_deref());
     let consumer = http_indexer::Consumer::new(&conn, queue_type.clone())

--- a/crates/indexer/src/http/client.rs
+++ b/crates/indexer/src/http/client.rs
@@ -1,17 +1,37 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use cid::Cid;
-use indexer_core::assets::ArTxid;
+use indexer_core::{assets::ArTxid, clap};
 use reqwest::Url;
 
-use crate::{db::Pool, prelude::*};
+use super::http_client_cache::HttpClientCache;
+use crate::{db::Pool, prelude::*, Params};
+
+/// Common arguments for internal HTTP indexer usage
+#[derive(Debug, clap::Parser)]
+#[allow(missing_copy_implementations)]
+pub struct Args {
+    /// A valid base URL to use when fetching IPFS links
+    #[clap(long, env)]
+    pub ipfs_cdn: String,
+
+    /// A valid base URL to use when fetching Arweave links
+    #[clap(long, env)]
+    pub arweave_cdn: String,
+
+    /// HTTP request timeout, in seconds
+    #[clap(long, env = "HTTP_INDEXER_TIMEOUT")]
+    pub timeout: f64,
+}
 
 /// Wrapper for handling networking logic
 #[derive(Debug)]
 pub struct Client {
     db: Pool,
+    http_clients: HttpClientCache,
     ipfs_cdn: Url,
     arweave_cdn: Url,
+    timeout: Duration,
 }
 
 impl Client {
@@ -20,14 +40,27 @@ impl Client {
     /// # Errors
     /// This function fails if an invalid URL is given for `ipfs_cdn` or
     /// `arweave_cdn`.
-    pub fn new_rc(db: Pool, ipfs_cdn: Url, arweave_cdn: Url) -> Result<Arc<Self>> {
+    pub fn new_rc(db: Pool, args: Args, params: &Params) -> Result<Arc<Self>> {
+        let Args {
+            ipfs_cdn,
+            arweave_cdn,
+            timeout,
+        } = args;
+
+        let ipfs_cdn: Url = ipfs_cdn.parse().context("Failed to parse IPFS CDN URL")?;
+        let arweave_cdn: Url = arweave_cdn
+            .parse()
+            .context("Failed to parse Arweave CDN URL")?;
+
         ensure!(!ipfs_cdn.cannot_be_a_base(), "Invalid IPFS CDN URL");
         ensure!(!arweave_cdn.cannot_be_a_base(), "Invalid Arweave CDN URL");
 
         Ok(Arc::new(Self {
             db,
+            http_clients: HttpClientCache::new(params.concurrency),
             ipfs_cdn,
             arweave_cdn,
+            timeout: Duration::from_secs_f64(timeout),
         }))
     }
 
@@ -35,6 +68,22 @@ impl Client {
     #[must_use]
     pub fn db(&self) -> &Pool {
         &self.db
+    }
+
+    /// Timeout hint for indexer HTTP requests
+    #[must_use]
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Acquire an HTTP client, using a URL hint to select a cache
+    ///
+    /// # Errors
+    /// This function returns an error if an HTTP client could not be acquired
+    /// or constructed.
+    #[inline]
+    pub fn http(&self, url: &Url) -> Result<super::http_client_cache::CachedClient> {
+        self.http_clients.acquire(url)
     }
 
     /// Construct an IPFS link from an IPFS CID

--- a/crates/indexer/src/http/http_client_cache.rs
+++ b/crates/indexer/src/http/http_client_cache.rs
@@ -1,0 +1,109 @@
+use std::{
+    hash::{BuildHasher, Hash, Hasher},
+    mem::ManuallyDrop,
+    sync::Arc,
+};
+
+use crossbeam::queue::ArrayQueue;
+use indexer_core::{ahash::RandomState, prelude::*};
+use reqwest::{Client, Url};
+
+const MAX_WIDTH: usize = 32;
+
+#[derive(Debug)]
+pub struct HttpClientCache {
+    hasher_builder: RandomState,
+    clients: [Arc<ArrayQueue<Client>>; MAX_WIDTH],
+}
+
+impl HttpClientCache {
+    pub fn new(depth: usize) -> Self {
+        Self {
+            hasher_builder: RandomState::new(),
+            clients: std::iter::repeat_with(|| Arc::new(ArrayQueue::new(depth)))
+                .take(MAX_WIDTH)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        }
+    }
+
+    pub fn acquire(&self, url: &Url) -> Result<CachedClient> {
+        let mut hasher = self.hasher_builder.build_hasher();
+        url.host_str()
+            .ok_or_else(|| anyhow!("Missing host identifier for cache"))?
+            .hash(&mut hasher);
+        let hash = hasher.finish();
+
+        let idx: usize = hash
+            .rem_euclid(
+                self.clients
+                    .len()
+                    .try_into()
+                    .unwrap_or_else(|_| unreachable!()),
+            )
+            .try_into()
+            .unwrap_or_else(|_| unreachable!());
+        // Safety: because of rem_euclid idx < self.clients.len()
+        let q = unsafe { self.clients.get_unchecked(idx) };
+
+        trace!("Checking out client for {:?} at slot {}", url, idx);
+
+        let client = q.pop().unwrap_or_else(|| {
+            trace!("No clients to check out in slot {}", idx);
+
+            Client::new()
+        });
+
+        Ok(CachedClient {
+            cache: q.clone(),
+            client: ManuallyDrop::new(client),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct CachedClient {
+    cache: Arc<ArrayQueue<Client>>,
+    client: ManuallyDrop<Client>,
+}
+
+impl Drop for CachedClient {
+    fn drop(&mut self) {
+        match self
+            .cache
+            .push(unsafe { ManuallyDrop::take(&mut self.client) })
+        {
+            Ok(()) => (), // client was successfully moved out, do NOT drop
+            Err(c) => {
+                trace!("Queue depth exceeded, not checking client back in");
+
+                // IMPORTANT: c is a copy of the original client, we want to
+                //            only drop the original
+                std::mem::forget(c);
+                unsafe {
+                    ManuallyDrop::drop(&mut self.client);
+                }
+            },
+        }
+    }
+}
+
+impl AsRef<Client> for CachedClient {
+    fn as_ref(&self) -> &Client {
+        &self.client
+    }
+}
+
+impl std::borrow::Borrow<Client> for CachedClient {
+    fn borrow(&self) -> &Client {
+        &self.client
+    }
+}
+impl std::ops::Deref for CachedClient {
+    type Target = Client;
+
+    fn deref(&self) -> &Client {
+        &self.client
+    }
+}

--- a/crates/indexer/src/http/metadata_json.rs
+++ b/crates/indexer/src/http/metadata_json.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Debug, Display},
-    time::Duration,
-};
+use std::fmt::{self, Debug, Display};
 
 use cid::Cid;
 use indexer_core::{
@@ -112,19 +109,17 @@ enum MetadataJsonResult {
 }
 
 async fn fetch_json(
-    http_client: reqwest::Client,
+    client: &Client,
     meta_key: Pubkey,
     url: Result<Url>,
 ) -> Result<MetadataJsonResult> {
     let start_time = Local::now();
     let url = url.context("Failed to create asset URL")?;
 
-    // TODO: what's a good timeout?
-    let timeout = Duration::from_secs(10);
-
-    let bytes = http_client
+    let bytes = client
+        .http(&url)?
         .get(url.clone())
-        .timeout(timeout)
+        .timeout(client.timeout())
         .send()
         .await
         .context("Metadata JSON request failed")?
@@ -171,7 +166,6 @@ async fn try_locate_json(
     id: &AssetIdentifier,
     meta_key: Pubkey,
 ) -> Result<(MetadataJsonResult, Vec<u8>)> {
-    let http_client = reqwest::Client::new();
     let mut resp = None;
 
     for (url, fingerprint) in id
@@ -182,7 +176,7 @@ async fn try_locate_json(
     {
         let url_str = url.as_ref().map_or("???", Url::as_str).to_owned();
 
-        match fetch_json(http_client.clone(), meta_key, url).await {
+        match fetch_json(client, meta_key, url).await {
             Ok(j) => {
                 debug!("Using fetch from {:?} for metadata {}", url_str, meta_key);
                 resp = Some((j, fingerprint));
@@ -202,7 +196,7 @@ async fn try_locate_json(
 
         if TRY_LAST_RESORT {
             (
-                fetch_json(http_client, meta_key, Ok(url.clone()))
+                fetch_json(client, meta_key, Ok(url.clone()))
                     .await
                     .with_context(|| {
                         format!(

--- a/crates/indexer/src/http/mod.rs
+++ b/crates/indexer/src/http/mod.rs
@@ -1,10 +1,11 @@
 //! Support features for the HTTP indexer
 
 pub(self) mod client;
+pub(self) mod http_client_cache;
 mod metadata_json;
 mod store_config;
 
-pub use client::Client;
+pub use client::{Args as ClientArgs, Client};
 use indexer_rabbitmq::http_indexer::{Entity, MetadataJson, StoreConfig};
 
 use crate::prelude::*;

--- a/crates/indexer/src/http/store_config.rs
+++ b/crates/indexer/src/http/store_config.rs
@@ -59,16 +59,16 @@ struct SettingUri {
 pub async fn process(client: &Client, config_key: Pubkey, uri_str: String) -> Result<()> {
     let url = Url::parse(&uri_str).context("Couldn't parse store config URL")?;
 
-    let http_client = reqwest::Client::new();
-
     debug!(
         "attempting to process storeconfig: {:?}, with uri: {:?}",
         config_key, uri_str
     );
 
     // TODO: parse failure shouldn't be an error, this stuff will be unstructured
-    let json = http_client
+    let json = client
+        .http(&url)?
         .get(url)
+        .timeout(client.timeout())
         .send()
         .await
         .context("Metadata JSON request failed")?

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -153,7 +153,10 @@ mod runtime {
                 Err(e) => {
                     warn!("Could not gracefully join worker task: {:?}", e);
 
-                    Ok(())
+                    acker
+                        .reject(BasicRejectOptions { requeue: false })
+                        .await
+                        .context("Failed to send NAK for panicked delivery")
                 },
             }
         }

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -53,7 +53,7 @@ mod runtime {
     #[allow(missing_copy_implementations)]
     #[derive(Debug)]
     pub struct Params {
-        concurrency: usize,
+        pub(crate) concurrency: usize,
     }
 
     /// Entrypoint for `metaplex-indexer` binaries


### PR DESCRIPTION
Items in this PR:
- Send a `basic.reject` for messages where a worker panic occurred
- Add a configurable timeout to the HTTP indexers
- Optimistically attempt to reuse HTTP clients