### PR TITLE
[Fix] Store Config JSON File Field Parsing

### DIFF
--- a/crates/indexer/src/http/store_config.rs
+++ b/crates/indexer/src/http/store_config.rs
@@ -34,9 +34,9 @@ pub struct Address {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Upload {
     pub url: String,
-    pub name: String,
+    pub name: Option<String>,
     #[serde(rename = "type")]
-    pub ty: String,
+    pub ty: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
### Changes

- Make type and name optional on storeconfig json. When those arent set and the marketplace is edited they are undefined. Fine but needs to be considered valid json scheme.