### PR TITLE
Remove configurable API version, lock at v1.

### DIFF
--- a/crates/graphql/src/main.rs
+++ b/crates/graphql/src/main.rs
@@ -32,9 +32,6 @@ struct Opts {
 
     #[clap(long, env)]
     asset_proxy_count: u8,
-
-    #[clap(long, env, default_value = "0")]
-    api_version: String,
 }
 
 fn graphiql(uri: String) -> impl Fn() -> HttpResponse + Clone {
@@ -85,7 +82,6 @@ fn main() {
             twitter_bearer_token,
             asset_proxy_endpoint,
             asset_proxy_count,
-            api_version,
         } = Opts::parse();
 
         let (addr,) = server.into_parts();
@@ -103,13 +99,10 @@ fn main() {
             db::connect(db::ConnectMode::Read).context("Failed to connect to Postgres")?;
         let db_pool = Arc::new(db_pool);
 
-        let version_extension = format!(
-            "/v{}",
-            percent_encoding::utf8_percent_encode(&api_version, percent_encoding::NON_ALPHANUMERIC,)
-        );
+        let version_extension = "/v1";
 
         // Should look something like "/..."
-        let graphiql_uri = version_extension.clone();
+        let graphiql_uri = version_extension.to_owned();
         assert!(graphiql_uri.starts_with('/'));
 
         let schema = Arc::new(schema::create());
@@ -132,7 +125,7 @@ fn main() {
                                 .max_age(3600),
                         )
                         .service(
-                            web::resource(&version_extension)
+                            web::resource(version_extension)
                                 .route(web::post().to(graphql(db_pool.clone(), shared.clone()))),
                         )
                         .service(


### PR DESCRIPTION
We need to be absolutely sure nothing is pointing at `graph-test.holaplex.com/v0` before merging this.