### PR TITLE
Fixes Collection Preview After Token Address Exposed on NFT

### DIFF
--- a/crates/core/migrations/2022-07-22-144824_add_index_creator_address_to_store_creators/down.sql
+++ b/crates/core/migrations/2022-07-22-144824_add_index_creator_address_to_store_creators/down.sql
@@ -1,0 +1,1 @@
+drop index if exists creator_address_store_creators_idx;

--- a/crates/core/migrations/2022-07-22-144824_add_index_creator_address_to_store_creators/up.sql
+++ b/crates/core/migrations/2022-07-22-144824_add_index_creator_address_to_store_creators/up.sql
@@ -1,0 +1,2 @@
+create index if not exists creator_address_store_creators_idx on 
+  store_creators using hash (creator_address);

--- a/crates/graphql/src/schema/dataloaders/collection.rs
+++ b/crates/graphql/src/schema/dataloaders/collection.rs
@@ -16,7 +16,7 @@ impl TryBatchFn<PublicKey<StoreCreator>, Vec<Nft>> for Batcher {
         let conn = self.db()?;
 
         let rows: Vec<models::SampleNft> = sql_query(
-            "SELECT DISTINCT ON (sample_metadatas.address)
+            "SELECT sample_metadatas.address,
                     sample_metadatas.creator_address,
                     sample_metadatas.address,
                     sample_metadatas.name,
@@ -53,7 +53,7 @@ impl TryBatchFn<PublicKey<StoreCreator>, Vec<Nft>> for Batcher {
                     FROM metadatas
                     INNER JOIN metadata_jsons ON (metadatas.address = metadata_jsons.metadata_address)
                     INNER JOIN metadata_creators ON (metadatas.address = metadata_creators.metadata_address)
-                    INNER JOIN current_metadata_owners on (metadatas.address = current_metadata_owners.mint_address)
+                    INNER JOIN current_metadata_owners on (metadatas.mint_address = current_metadata_owners.mint_address)
                     WHERE metadata_creators.creator_address = store_creators.creator_address
                     LIMIT 3
                 ) AS sample_metadatas ON true


### PR DESCRIPTION
### Changes
Adjust collection nft query to correctly expose token_account_address
- Add index on creator_address after analyzing the query. A seq scan though the table is pretty small.