### PR TITLE
add ability to get metadata image URL from NFT

### DIFF
--- a/crates/graphql/src/schema/objects/nft.rs
+++ b/crates/graphql/src/schema/objects/nft.rs
@@ -442,6 +442,11 @@ If no value is provided, it will return XSmall")))]
         )
     }
 
+    #[graphql(description = r"Get the original URL of the image as stored in the NFT's metadata")]
+    pub fn image_original(&self) -> &str {
+        &self.image
+    }
+
     pub fn animation_url(&self) -> Option<&str> {
         self.animation_url.as_deref()
     }


### PR DESCRIPTION
This PR adds the ability to query the NFT's original metadata image URL in addition to the indexer optimized image by exposing a new field `imageOriginal`